### PR TITLE
Fix API route returning 500 for auth errors

### DIFF
--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -1,19 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
 
 const BASE_API_URL = "https://seanofthe.dev/hoops-vs-beans-api";
-const apiKey = process.env.API_KEY as string;
+const apiKey = process.env.API_KEY;
+
 export async function GET() {
-    
+    if (!apiKey) {
+        return NextResponse.json({ error: "API key is not configured" }, { status: 401 });
+    }
+
     try {
         const res = await fetch(`${BASE_API_URL}/VoteCount`, {
                 headers: {
                         'X-Api-Key': apiKey,
                 },
         });
-        
+
         if (!res.ok) {
             console.error("Failed to fetch vote count:", res.statusText);
-            throw new Error("Failed to fetch vote count");
+            return NextResponse.json({ error: "Failed to fetch vote count" }, { status: res.status });
         }
 
         const data = await res.json();
@@ -25,11 +29,15 @@ export async function GET() {
 }
 
 export async function PUT(req: NextRequest) {
+    if (!apiKey) {
+        return NextResponse.json({ error: "API key is not configured" }, { status: 401 });
+    }
+
     try {
         const body = await req.json();
 
         const option = body.voteOption?.toLowerCase();
-        
+
         if (option !== "hoops" && option !== "beans") {
             console.error("Invalid vote option received:", option);
             return NextResponse.json({ error: "Invalid vote option" }, { status: 400 });
@@ -45,7 +53,7 @@ export async function PUT(req: NextRequest) {
 
         if (!res.ok) {
             console.error("External API returned error:", res.statusText);
-            throw new Error("Failed to submit vote");
+            return NextResponse.json({ error: "Failed to submit vote" }, { status: res.status });
         }
 
         const updatedVotes = await res.json();


### PR DESCRIPTION
## Summary
- Return **401** when `API_KEY` environment variable is not configured, instead of letting requests fail through to a misleading **500**
- Forward the upstream API's actual status code (e.g. 401, 403, 404) on non-ok responses instead of catching all errors as 500
- Remove unsafe `as string` cast on `process.env.API_KEY` so the missing-key check works correctly

## Test plan
- [ ] Start dev server **without** `API_KEY` set → GET and PUT `/api/votes` should return `401` with `{"error":"API key is not configured"}`
- [ ] Start dev server **with** valid `API_KEY` in `.env.local` → GET and PUT `/api/votes` should return `200` with vote data
- [ ] Verify `.env.local` is not included in the commit (gitignored)
- [ ] After merging, add `API_KEY` environment variable in Vercel project settings and redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)